### PR TITLE
Adds public initializer to NetworkActivityPlugin

### DIFF
--- a/Source/Core/NetworkActivityPlugin.swift
+++ b/Source/Core/NetworkActivityPlugin.swift
@@ -42,6 +42,8 @@ public class NetworkActivityPlugin : Plugin {
         }
     }
     
+    public init() {}
+    
     public func willSendRequest(request: NSURLRequest?) {
         self.dynamicType.networkActivityCount++
     }


### PR DESCRIPTION
I was following the tutorial of plugins but the NetworkActivityPlugin cannot be created like the example.

This commit adds a public initializer... that's it
