### PR TITLE
stop calling UIApplication methods from background thread

### DIFF
--- a/Source/NetworkActivityPlugin.swift
+++ b/Source/NetworkActivityPlugin.swift
@@ -46,7 +46,9 @@ open class NetworkActivityPlugin : Plugin {
      */
     var networkActivityCount = 0 {
         didSet {
-            application.isNetworkActivityIndicatorVisible = networkActivityCount > 0
+            DispatchQueue.main.async { [unowned self] in
+                self.application.isNetworkActivityIndicatorVisible = self.networkActivityCount > 0
+            }
         }
     }
     


### PR DESCRIPTION
This change makes Xcode 9 Main Thread Checker happy.

With the current implementation of `NetworkActivityPlugin`, happy users (?) of Xcode 9 beta, are getting the following stack in the console:
```
2017-09-03 16:24:04.492139-0700 tripbot-ios[4305:1867173] refreshPreferences: ActivationLoggingEnabled: 0 ActivationLoggingTaskedOffByDA:0
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIApplication setNetworkActivityIndicatorVisible:]
PID: 4305, TID: 1867329, Thread name: (none), Queue name: NSOperationQueue 0x1c4038300 (QOS: UTILITY), QoS: 17
Backtrace:
4   TRON                                0x0000000105c214d0 _T04TRON21NetworkActivityPluginC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt8response_9Alamofire7RequestC03forO0AA04BaseO0Cyxq_G10formedFromtr0_lFTf4ddddddn_n + 184
5   TRON                                0x0000000105c21120 _T04TRON21NetworkActivityPluginC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt8response_9Alamofire7RequestC03forO0AA04BaseO0Cyxq_G10formedFromtr0_lF + 52
6   TRON                                0x0000000105c21328 _T04TRON21NetworkActivityPluginCAA0D0A2aDP19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAG4DataVSgs5Error_pSgt8response_9Alamofire7RequestC03forO0AA04BaseO0Cyqd__qd_0_G10formedFromtr0_lFTW + 188
7   TRON                                0x0000000105c0dc18 _T04TRON11BaseRequestC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt_9Alamofire0C0C3fortFyAA6Plugin_pcfU_Tf4nggg_n + 228
8   TRON                                0x0000000105c0a738 _T04TRON11BaseRequestC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt_9Alamofire0C0C3fortFyAA6Plugin_pcfU_ + 64
9   TRON                                0x0000000105c0ccf4 _T04TRON11BaseRequestC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt_9Alamofire0C0C3fortFyAA6Plugin_pcfU_TA + 148
10  TRON                                0x0000000105c0b0a8 _T0s8SequencePsE7forEachyy7ElementQzKcKFTfq4gn_nSay4TRON6Plugin_pG_Tg5 + 232
11  TRON                                0x0000000105c0a69c _T04TRON11BaseRequestC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt_9Alamofire0C0C3fortF + 208
12  TRON                                0x0000000105c22210 _T04TRON10APIRequestC22dataResponseSerializer9Alamofire04DatadE0VyxGAE7RequestC4with_tFAE6ResultOyxG10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAO0G0VSgs5Error_pSgtcfU_ + 708
13  Alamofire                           0x0000000105614478 _T09Alamofire11DataRequestC8responseACXDSo13DispatchQueueCSg5queue_x0D10SerializeryAA0B8ResponseVy16SerializedObjectQzGc17completionHandlertAA0biH8ProtocolRzlFyycfU_Tf4gggg_n + 1460
14  Alamofire                           0x0000000105611a20 _T09Alamofire11DataRequestC8responseACXDSo13DispatchQueueCSg5queue_x0D10SerializeryAA0B8ResponseVy16SerializedObjectQzGc17completionHandlertAA0biH8ProtocolRzlFyycfU_TATm + 120
15  Alamofire                           0x000000010560ea68 _T0Ix_IyB_TR + 36
16  Foundation                          0x0000000183023310 <redacted> + 16
17  Foundation                          0x0000000182f639e4 <redacted> + 72
18  Foundation                          0x0000000182f53620 <redacted> + 848
19  libdispatch.dylib                   0x000000010750d45c _dispatch_client_callout + 16
20  libdispatch.dylib                   0x0000000107519b74 _dispatch_block_invoke_direct + 268
21  libdispatch.dylib                   0x000000010750d45c _dispatch_client_callout + 16
22  libdispatch.dylib                   0x0000000107519b74 _dispatch_block_invoke_direct + 268
23  libdispatch.dylib                   0x0000000107519a34 dispatch_block_perform + 104
24  Foundation                          0x0000000183024fe8 <redacted> + 376
25  libdispatch.dylib                   0x000000010750d45c _dispatch_client_callout + 16
26  libdispatch.dylib                   0x000000010751a800 _dispatch_continuation_pop + 592
27  libdispatch.dylib                   0x000000010751909c _dispatch_async_redirect_invoke + 628
28  libdispatch.dylib                   0x000000010751eb54 _dispatch_root_queue_drain + 616
29  libdispatch.dylib                   0x000000010751e880 _dispatch_worker_thread3 + 136
30  libsystem_pthread.dylib 2017-09-03 16:24:04.851456-0700 tripbot-ios[4305:1867329] [reports] Main Thread Checker: UI API called on a background thread: -[UIApplication setNetworkActivityIndicatorVisible:]
PID: 4305, TID: 1867329, Thread name: (none), Queue name: NSOperationQueue 0x1c4038300 (QOS: UTILITY), QoS: 17
Backtrace:
4   TRON                                0x0000000105c214d0 _T04TRON21NetworkActivityPluginC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt8response_9Alamofire7RequestC03forO0AA04BaseO0Cyxq_G10formedFromtr0_lFTf4ddddddn_n + 184
5   TRON                                0x0000000105c21120 _T04TRON21NetworkActivityPluginC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt8response_9Alamofire7RequestC03forO0AA04BaseO0Cyxq_G10formedFromtr0_lF + 52
6   TRON                                0x0000000105c21328 _T04TRON21NetworkActivityPluginCAA0D0A2aDP19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAG4DataVSgs5Error_pSgt8response_9Alamofire7RequestC03forO0AA04BaseO0Cyqd__qd_0_G10formedFromtr0_lFTW + 188
7   TRON                                0x0000000105c0dc18 _T04TRON11BaseRequestC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt_9Alamofire0C0C3fortFyAA6Plugin_pcfU_Tf4nggg_n + 228
8   TRON                                0x0000000105c0a738 _T04TRON11BaseRequestC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt_9Alamofire0C0C3fortFyAA6Plugin_pcfU_ + 64
9   TRON                                0x0000000105c0ccf4 _T04TRON11BaseRequestC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt_9Alamofire0C0C3fortFyAA6Plugin_pcfU_TA + 148
10  TRON                                0x0000000105c0b0a8 _T0s8SequencePsE7forEachyy7ElementQzKcKFTfq4gn_nSay4TRON6Plugin_pG_Tg5 + 232
11  TRON                                0x0000000105c0a69c _T04TRON11BaseRequestC19willProcessResponsey10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAE4DataVSgs5Error_pSgt_9Alamofire0C0C3fortF + 208
12  TRON                                0x0000000105c22210 _T04TRON10APIRequestC22dataResponseSerializer9Alamofire04DatadE0VyxGAE7RequestC4with_tFAE6ResultOyxG10Foundation10URLRequestVSg_So15HTTPURLResponseCSgAO0G0VSgs5Error_pSgtcfU_ + 708
13  Alamofire                           0x0000000105614478 _T09Alamofire11DataRequestC8responseACXDSo13DispatchQueueCSg5queue_x0D10SerializeryAA0B8ResponseVy16SerializedObjectQzGc17completionHandlertAA0biH8ProtocolRzlFyycfU_Tf4gggg_n + 1460
14  Alamofire                           0x0000000105611a20 _T09Alamofire11DataRequestC8responseACXDSo13DispatchQueueCSg5queue_x0D10SerializeryAA0B8ResponseVy16SerializedObjectQzGc17completionHandlertAA0biH8ProtocolRzlFyycfU_TATm + 120
15  Alamofire                           0x000000010560ea68 _T0Ix_IyB_TR + 36
16  Foundation                          0x0000000183023310 <redacted> + 16
17  Foundation                          0x0000000182f639e4 <redacted> + 72
18  Foundation                          0x0000000182f53620 <redacted> + 848
19  libdispatch.dylib                   0x000000010750d45c _dispatch_client_callout + 16
20  libdispatch.dylib                   0x0000000107519b74 _dispatch_block_invoke_direct + 268
21  libdispatch.dylib                   0x000000010750d45c _dispatch_client_callout + 16
22  libdispatch.dylib                   0x0000000107519b74 _dispatch_block_invoke_direct + 268
23  libdispatch.dylib                   0x0000000107519a34 dispatch_block_perform + 104
24  Foundation                          0x0000000183024fe8 <redacted> + 376
25  libdispatch.dylib                   0x000000010750d45c _dispatch_client_callout + 16
26  libdispatch.dylib                   0x000000010751a800 _dispatch_continuation_pop + 592
27  libdispatch.dylib                   0x000000010751909c _dispatch_async_redirect_invoke + 628
28  libdispatch.dylib                   0x000000010751eb54 _dispatch_root_queue_drain + 616
29  libdispatch.dylib                   0x000000010751e880 _dispatch_worker_thread3 + 136
30  libsystem_pthread.dylib
```