### PR TITLE
Set correct Alamofire version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "Alamofire/Alamofire" "5.0.0-beta.7"
+github "Alamofire/Alamofire" "5.0.0-rc.1"
 github "SwiftyJSON/SwiftyJSON"
 github "ReactiveX/RxSwift"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Alamofire/Alamofire" "5.0.0-beta.7"
+github "Alamofire/Alamofire" "5.0.0-rc.1"
 github "ReactiveX/RxSwift" "5.0.1"
 github "SwiftyJSON/SwiftyJSON" "5.0.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "a6241748b5c5f38ca53fa8286788d2f90fa9c666",
-          "version": "5.0.0-beta.7"
+          "revision": "82cc60d703dbced153baa04e26c6296ba9690a2d",
+          "version": "5.0.0-rc.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .library(name: "RxTRON", targets: ["RxTRON"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.0.0-beta.7")),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.0.0-rc.1")),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", .upToNextMajor(from: ("5.0.0"))),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0"))
     ],

--- a/TRON.podspec
+++ b/TRON.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.12'
   s.watchos.deployment_target = '3.0'
 
-  s.dependency 'Alamofire' , '~> 5.0.0-beta.7'
+  s.dependency 'Alamofire' , '~> 5.0.0-rc.1'
 
   s.subspec 'Core' do |core|
       core.ios.frameworks = 'UIKit'


### PR DESCRIPTION
Second generic argument in Response structs was introduced in https://github.com/Alamofire/Alamofire/commit/755dd5139bb19db92024da68fbb36897c17ad1ce#diff-0532e61b339db1c06287f9110afe7dfc which was released as part of rc.1 version, not beta.7.