### PR TITLE
Updated requests logging according to current Alamofire version

### DIFF
--- a/Source/TRON/NetworkLoggerPlugin.swift
+++ b/Source/TRON/NetworkLoggerPlugin.swift
@@ -54,7 +54,7 @@ open class NetworkLoggerPlugin: Plugin {
     /// Called, when response was successfully parsed. If `logSuccess` property has been turned on, prints cURL representation of request.
     open func didSuccessfullyParseResponse<Model, ErrorModel>(_ response: (URLRequest?, HTTPURLResponse?, Data?, Error?), creating result: Model, forRequest request: Request, formedFrom tronRequest: BaseRequest<Model, ErrorModel>) {
         if logSuccess {
-            debugPrint(request)
+            print(request.cURLDescription())
             print("Request success ✅")
         }
     }
@@ -66,7 +66,7 @@ open class NetworkLoggerPlugin: Plugin {
                 return
             }
             print("❗️ Request errored, gathered debug information: ")
-            debugPrint(request)
+            print(request.cURLDescription())
 
             print("⚠️ Response status code - \(response.1?.statusCode ?? 0)")
             if let responseData = response.2 {


### PR DESCRIPTION
In `Alamofire 5.0.0.beta.7` the `debugDescription` method of `Request` has been removed and `cURLRepresentation` has been renamed to `cURLDescription` and made public. We need to make following changes to preserve the way how requests are logged, otherwise the `description` will be used which contains only method, url and status code.