### PR TITLE
Added exported imports for several Alamofire types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 # Next
 
+### Changed
+
+* Several `Alamofire` types that are exposed through TRON API's are now implicitly exported to allow using them without needing to write `import Alamofire`. See `Exports.swift` file for a list of them.
+
 ## [5.0.3](https://github.com/MLSDev/TRON/releases/tag/5.0.3)
 
 ### Added

--- a/Source/TRON/Exports.swift
+++ b/Source/TRON/Exports.swift
@@ -1,0 +1,33 @@
+//
+//  Exports.swift
+//  TRON
+//
+//  Created by Denys Telezhkin on 29.04.2020.
+//  Copyright © 2015 - present MLSDev. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_exported import protocol Alamofire.RequestInterceptor
+@_exported import class Alamofire.Session
+@_exported import class Alamofire.Request
+@_exported import struct Alamofire.Empty
+@_exported import class Alamofire.DownloadRequest
+@_exported import class Alamofire.MultipartFormData
+@_exported import protocol Alamofire.DataResponseSerializerProtocol
+@_exported import protocol Alamofire.DownloadResponseSerializerProtocol

--- a/Source/TRON/Serialization.swift
+++ b/Source/TRON/Serialization.swift
@@ -3,8 +3,25 @@
 //  TRON
 //
 //  Created by Denys Telezhkin on 12/21/18.
-//  Copyright © 2018 Denys Telezhkin. All rights reserved.
+//  Copyright © 2015 - present MLSDev. All rights reserved.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 import Foundation
 import Alamofire

--- a/Source/Tests/APIRequestTestCase.swift
+++ b/Source/Tests/APIRequestTestCase.swift
@@ -9,7 +9,6 @@
 import Foundation
 import TRON
 import XCTest
-import Alamofire
 
 extension Data {
     var asString: String {

--- a/Source/Tests/ApiStubbingTestCase.swift
+++ b/Source/Tests/ApiStubbingTestCase.swift
@@ -10,7 +10,6 @@ import TRON
 import TRONSwiftyJSON
 import XCTest
 import SwiftyJSON
-import Alamofire
 
 struct TestUser: JSONDecodable {
     let name: String

--- a/Source/Tests/CodableTestCase.swift
+++ b/Source/Tests/CodableTestCase.swift
@@ -9,7 +9,6 @@
 import TRON
 import Foundation
 import XCTest
-import Alamofire
 
 private struct CodableResponse: Codable {
     let title: String

--- a/Source/Tests/DownloadTestCase.swift
+++ b/Source/Tests/DownloadTestCase.swift
@@ -9,7 +9,6 @@
 import Foundation
 import XCTest
 import TRON
-import Alamofire
 
 class DownloadTestCase: ProtocolStubbedTestCase {
 

--- a/Source/Tests/PluginTestCase.swift
+++ b/Source/Tests/PluginTestCase.swift
@@ -8,7 +8,6 @@
 
 import TRON
 import XCTest
-import Alamofire
 
 class PluginTestCase: ProtocolStubbedTestCase {
 

--- a/Source/Tests/PluginTester.swift
+++ b/Source/Tests/PluginTester.swift
@@ -7,7 +7,6 @@
 //
 
 import TRON
-import Alamofire
 import Foundation
 
 class PluginTester: Plugin {

--- a/Source/Tests/ProtocolStubbedTestCase.swift
+++ b/Source/Tests/ProtocolStubbedTestCase.swift
@@ -8,7 +8,6 @@
 
 import TRON
 import XCTest
-import Alamofire
 
 class ProtocolStubbedTestCase: XCTestCase {
 

--- a/Source/Tests/ResponseSerializationTestCase.swift
+++ b/Source/Tests/ResponseSerializationTestCase.swift
@@ -6,9 +6,10 @@
 //  Copyright © 2016 Denys Telezhkin. All rights reserved.
 //
 
-import Alamofire
 import TRON
 import XCTest
+import protocol Alamofire.DataResponseSerializerProtocol
+import class Alamofire.StringResponseSerializer
 
 protocol Food {}
 

--- a/TRON.xcodeproj/project.pbxproj
+++ b/TRON.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		9A9803F122D78987008CB92C /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 9A9803F022D78987008CB92C /* RxSwift */; };
 		9A9803F422D789A4008CB92C /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 9A9803F322D789A4008CB92C /* SwiftyJSON */; };
 		9A9803FB22D78CAD008CB92C /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 9A9803FA22D78CAD008CB92C /* Alamofire */; };
+		9ABE13FD2459A2BB008874D2 /* Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ABE13FC2459A2BB008874D2 /* Exports.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -194,6 +195,7 @@
 		9AB63D2B22731CD300544A3E /* PluginConcepts.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PluginConcepts.md; sourceTree = "<group>"; };
 		9AB63D2C22731CD300544A3E /* ContainerTypesParsing.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ContainerTypesParsing.md; sourceTree = "<group>"; };
 		9AB63D2D22731CFB00544A3E /* 5.0 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "5.0 Migration Guide.md"; sourceTree = "<group>"; };
+		9ABE13FC2459A2BB008874D2 /* Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exports.swift; sourceTree = "<group>"; };
 		9AFAE4D41CC5210F002739B0 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		9AFAE4D51CC52118002739B0 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -297,6 +299,7 @@
 				3EC5C8C322A7E78F00B42774 /* APIRequest.swift */,
 				3EC5C8C422A7E78F00B42774 /* Plugin.swift */,
 				3EC5C8C522A7E78F00B42774 /* Serialization.swift */,
+				9ABE13FC2459A2BB008874D2 /* Exports.swift */,
 			);
 			path = TRON;
 			sourceTree = "<group>";
@@ -658,6 +661,7 @@
 				3EC5C8CF22A7E78F00B42774 /* DownloadAPIRequest.swift in Sources */,
 				3EC5C8CD22A7E78F00B42774 /* TRONCodable.swift in Sources */,
 				3EC5C8D122A7E78F00B42774 /* URLBuilder.swift in Sources */,
+				9ABE13FD2459A2BB008874D2 /* Exports.swift in Sources */,
 				3EC5C8D022A7E78F00B42774 /* NetworkActivityPlugin.swift in Sources */,
 				3EC5C8CA22A7E78F00B42774 /* APIError.swift in Sources */,
 				3EC5C8C822A7E78F00B42774 /* APIStub.swift in Sources */,


### PR DESCRIPTION
While TRON is a wrapper around `Alamofire` API's, several of `Alamofire` types have been exposed through TRON interface, forcing a user to explicitly write `import Alamofire` along with `import TRON` to use them.

It's possible to write an implicit import, that exports entire framework to another framework users(see [example](https://github.com/DenTelezhkin/DTTableViewManager/blob/master/Sources/DTTableViewManager/Exports.swift#L26), [advanced example](https://github.com/vapor/vapor/blob/master/Sources/Vapor/Exports.swift)). TRON - Alamofire situation is a little different, however, since TRON wraps some API's and discourages user from using Alamofire API's directly.

Therefore, this PR aims to export only specific types from Alamofire, that are actually exposed by TRON API. 

Downside of this PR is that if TRON API user had local API's that clash with Alamofire naming(for example, local `Session` type, or local `Request` type), this change would actually be breaking and would require to explicitly disambiguate those types(`Alamofire.Request`).